### PR TITLE
Fix event details page not showing  local timezone of the event

### DIFF
--- a/src/components/Event.tsx
+++ b/src/components/Event.tsx
@@ -12,6 +12,7 @@ import {
   Spinner,
   Button,
   Stack,
+  Tooltip,
 } from '@chakra-ui/react';
 import Breadcrumbs from './Breadcrumbs';
 import Error from './Error';
@@ -23,7 +24,9 @@ interface EventInfoProps {
   event: {
     short_title: string;
     datetime_utc: Date;
-    venue: Venue;
+    venue: Venue & {
+      timezone: string;
+    };
     url: string;
   }
 }
@@ -78,7 +81,11 @@ const EventInfo: React.FC<EventInfoProps> = ({ event }) => (
         <StatLabel display="flex">
           <Box as="span">Date</Box>
         </StatLabel>
-        <StatNumber fontSize="xl">{formatDateTime(event.datetime_utc)}</StatNumber>
+        <Tooltip label={formatDateTime(event.datetime_utc)} aria-label="Event Date">
+          <StatNumber fontSize="xl">
+            {formatDateTime(event.datetime_utc, event.venue.timezone)}
+          </StatNumber>
+        </Tooltip>
       </Stat>
     </SimpleGrid>
     <Flex>

--- a/src/utils/formatDateTime.ts
+++ b/src/utils/formatDateTime.ts
@@ -1,4 +1,5 @@
-export function formatDateTime(timestamp: Date) {
+export function formatDateTime(timestamp: Date, timezone?: string) {
+  // 'Z' ensures timestamp is parsed as UTC, not local time
   return new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
     month: 'long',
@@ -7,5 +8,6 @@ export function formatDateTime(timestamp: Date) {
     minute: 'numeric',
     second: 'numeric',
     timeZoneName: 'short',
-  }).format(new Date(timestamp));
+    timeZone: timezone,
+  }).format(new Date(timestamp + 'Z'));
 }


### PR DESCRIPTION
### Summary
This PR fixes the issue where event times were displayed in the user's timezone. Now, event times are displayed in the venue's local timezone, while hovering over the time shows the user's local timezone in a tooltip.

### Changes
- Updated `Event.tsx`:
  - Added `Tooltip` around the datetime.
  - Display venue timezone in main view.
- Updated `formatDateTime.ts` to accept an optional `timezone` parameter.

### Notes
- This fix only affects display. Backend API remains unchanged.
- Future improvements could include formatting preferences per user.
